### PR TITLE
Friends Graph Efficiency Improvement (Closes #20)

### DIFF
--- a/public/js/githubAPI.js
+++ b/public/js/githubAPI.js
@@ -17,10 +17,6 @@ const API_ORG_MEMBERS = "/members";
 
 const API_REPOS = "/repos";
 
-const API_FOLLOWING = "/following";
-
-const API_FOLLOWERS = "/followers";
-
 const API_REPOSITORIES = "/repos";
 
 const API_ORGANIZATIONS = "/orgs";
@@ -31,39 +27,72 @@ const API_ORGANIZATIONS = "/orgs";
  * allows you to get at the data using a
  * callback which gives you a json object.
  *
- * @param apiPath the path on the github api ie API_FOLLOWING
  * @param user the username to query
  * @param successCallBack callback to complete when data is returned
  * @param errorCallBack callback which is invoked on error
  */
-function queryAPIByUser(apiPath, user, successCallBack, errorCallBack) {
+function queryAPIByUser(apiPath, user, successCallBack, errorCallBack) 
+{
     const urlpath = APIROOT + API_USER_PATH + user + apiPath;
-    console.log(urlpath);
-    $.ajax({
-        type:'GET',
-        url: urlpath,
-        dataType: "json",
-        success: successCallBack,
-        error:errorCallBack,
-        timeout: 4000
-    });
+    runAjax(urlpath, successCallBack, errorCallBack);
 }
 
-function queryAPIByOrg(apiPath, org, successCallBack, errorCallBack) {
+/**
+ * Makes API calls for orgs on github
+ * 
+ * @param {*} apiPath 
+ * @param {*} org 
+ * @param {*} successCallBack 
+ * @param {*} errorCallBack 
+ */
+function queryAPIByOrg(apiPath, org, successCallBack, errorCallBack)
+{
     const urlpath = APIROOT + API_ORG_PATH + org + apiPath;
-    console.log(urlpath);
-    $.ajax({
-        type:'GET',
-        url: urlpath,
-        dataType: "json",
-        success: successCallBack,
-        error:errorCallBack,
-        timeout: 4000
-    });
+    runAjax(urlpath, successCallBack, errorCallBack);
 }
 
-function queryUrl(url, successCallBack, errorCallBack) {
+
+/**
+ * Fetches a list of fiends for a user.
+ * 
+ * @param {*} userName 
+ * @param {*} suc 
+ * @param {*} err 
+ */
+function getFriendsAPI(userName, suc, err)
+{
+    // api/friends/jrtechs
+    const urlpath = APIROOT + "/friends/" + userName;
+    runAjax(urlpath, suc, err);
+}
+
+
+/**
+ * Queries github API end points with the backend
+ * proxy server for github graphs.
+ * 
+ * @param {*} url 
+ * @param {*} successCallBack 
+ * @param {*} errorCallBack 
+ */
+function queryUrl(url, successCallBack, errorCallBack)
+{
     url = url.split("https://api.github.com/").join("api/");
+    runAjax(url, successCallBack, errorCallBack);
+}
+
+
+/**
+ * Wrapper for AJAX calls so we can unify
+ * all of our settings.
+ * 
+ * @param {*} url -- url to query
+ * @param {*} successCallBack  -- callback with data retrieved
+ * @param {*} errorCallBack  -- callback with error message
+ */
+function runAjax(url, successCallBack, errorCallBack)
+{
+    console.log(url);
     $.ajax({
         type:'GET',
         url: url,


### PR DESCRIPTION
# What

This PR improves the performance of generating friends graphs.

# Things Done

- minimized JSON that gets stored on the backend and transmitted to the frontend
- takes advantage of pagination sizes meaning that we can make fewer queries to the API server
- create a custom endpoint on our API server for the frontend to interact with

# Results

These changes nearly halved the network bandwidth required to make a friends graph using the website. This also over halved the number of requests being made to our API server.

### before 

![originalJrtechsGraph](https://user-images.githubusercontent.com/13894625/71537400-7a25a580-28e9-11ea-9672-a04ea17d7d92.png)

### after

![afterThingie](https://user-images.githubusercontent.com/13894625/71537403-7db92c80-28e9-11ea-855c-b3a65460a691.png)

